### PR TITLE
assign correct IDs to imported fields, in order to update them

### DIFF
--- a/Migrate-Packages.php
+++ b/Migrate-Packages.php
@@ -367,6 +367,11 @@ class Pods_Migrate_Packages extends PodsComponent {
                     if ( isset( $field[ 'id' ] ) && !isset( $existing_fields[ $field[ 'name' ] ] ) )
                         unset( $pod[ 'fields' ][ $k ][ 'id' ] );
 
+                    if( isset( $existing_fields[$field['name']] ) ) {
+                        $existing_field = pods_api()->load_field( array( 'name' => $field['name'], 'pod' => $pod[ 'name' ] ) );
+                        $pod['fields'][$k]['id'] = $existing_field["id"];
+                    }
+
                     if ( isset( $field[ 'pod_id' ] ) )
                         unset( $pod[ 'fields' ][ $k ][ 'pod_id' ] );
 


### PR DESCRIPTION
otherwise it will result in a failed attempt to duplicate fields with the same name
